### PR TITLE
fix y level statement for ATMium in mining dimension

### DIFF
--- a/docs/atm9/allthemodium.md
+++ b/docs/atm9/allthemodium.md
@@ -13,7 +13,7 @@ In **ATM9**, All The Modium has changed in ways different from previous packs. W
 **AllTheModium** ores can be found across 3 dimensions: **Overworld**, **Nether**, and **The End**, normally exposed to **AIR**.
 
 - **AllTheModium**: (Overworld) ![](img/allthemodium_ore.gif){.absolute style='margin-left:5px'} ![](img/allthemodium_ingot.png){.absolute style='margin-left:45px'}
-    - Found in [Deep Dark](https://minecraft.fandom.com/wiki/Deep_Dark) Biome, also in **Mining Dimension** Deep Slate layer | Y 0-10.
+    - Found in [Deep Dark](https://minecraft.fandom.com/wiki/Deep_Dark) Biome, also in **Mining Dimension** Deep Slate layer (Y 64-128).
         - **Mining Dimension** is more rare, at-least 1 ore per chunk.
         - Killing **Warden** also grants a Quest reward ATM Ingot.
     - Obtained with a **Netherite** level pick or better. 

--- a/docs/atm9/allthemodium.md
+++ b/docs/atm9/allthemodium.md
@@ -13,7 +13,7 @@ In **ATM9**, All The Modium has changed in ways different from previous packs. W
 **AllTheModium** ores can be found across 3 dimensions: **Overworld**, **Nether**, and **The End**, normally exposed to **AIR**.
 
 - **AllTheModium**: (Overworld) ![](img/allthemodium_ore.gif){.absolute style='margin-left:5px'} ![](img/allthemodium_ingot.png){.absolute style='margin-left:45px'}
-    - Found in [Deep Dark](https://minecraft.fandom.com/wiki/Deep_Dark) Biome, also in **Mining Dimension** Deep Slate layer (Y 64-128).
+    - Found in [Deep Dark](https://minecraft.fandom.com/wiki/Deep_Dark) Biome, also in **Mining Dimension** Deep Slate layer (Y 65-129).
         - **Mining Dimension** is more rare, at-least 1 ore per chunk.
         - Killing **Warden** also grants a Quest reward ATM Ingot.
     - Obtained with a **Netherite** level pick or better. 


### PR DESCRIPTION
the current wiki page says y 0-10 in the mining dimension.
this is not the deepslate layer in the current (0.2.39) version, but the netherrack layer.
the ore actually spawns in the deepslate layer, which is between y 64 and y 128